### PR TITLE
Scan for YouTube players and init GIFit when one is found

### DIFF
--- a/dist/content.js
+++ b/dist/content.js
@@ -7,28 +7,52 @@ var React = require('react');
 var GifitButton = require('./components/GifitButton.jsx');
 var GifitApp = require('./components/GifitApp.jsx');
 
-// Find YouTube elements we'll be injecting into
-var youtube_player_chrome_element = document.querySelector('#player-api .html5-player-chrome');
-var youtube_player_controls_element = document.querySelector('#player-api .html5-video-controls');
+var initializeGifit = function( youtube_player_api_element ){
 
-// We need containers since React.renderComponent annihilates the contents of its target
-var gifit_button_container_element = document.createElement('div');
-gifit_button_container_element.classList.add('ytp-button', 'ytp-button-gif');
-var gifit_app_container_element = document.createElement('div');
-youtube_player_chrome_element.appendChild( gifit_button_container_element );
-youtube_player_controls_element.appendChild( gifit_app_container_element );
+	// Find YouTube elements we'll be injecting into
+	var youtube_player_chrome_element = youtube_player_api_element.querySelector(':scope .html5-player-chrome');
+	var youtube_player_controls_element = youtube_player_api_element.querySelector(':scope .html5-video-controls');
 
-// Prevent YouTube's events from firing in Gifit's interface
-var stopImmediatePropagation = function( event ){
-	event.stopImmediatePropagation();
+	// If GIFit can't find the appropriate elements it does not start
+	if( !youtube_player_controls_element || !youtube_player_chrome_element ){
+		return;
+	}
+
+	// GIFit needs containers since React.renderComponent annihilates the contents of its target
+	var gifit_button_container_element = document.createElement('div');
+	gifit_button_container_element.classList.add('ytp-button', 'ytp-button-gif');
+	var gifit_app_container_element = document.createElement('div');
+	youtube_player_chrome_element.appendChild( gifit_button_container_element );
+	youtube_player_controls_element.appendChild( gifit_app_container_element );
+
+	// Prevent YouTube's events from firing in GIFit's interface
+	var stopImmediatePropagation = function( event ){
+		event.stopImmediatePropagation();
+	};
+	gifit_app_container_element.addEventListener( 'keydown', stopImmediatePropagation );
+	gifit_app_container_element.addEventListener( 'keypress', stopImmediatePropagation );
+	gifit_app_container_element.addEventListener( 'contextmenu', stopImmediatePropagation );
+
+	// Engage party mode
+	React.render( React.createElement(GifitButton, null), gifit_button_container_element );
+	React.render( React.createElement(GifitApp, null), gifit_app_container_element );
+
+	// Mark territory
+	youtube_player_api_element.classList.add('gifit-initialized');
 };
-gifit_app_container_element.addEventListener( 'keydown', stopImmediatePropagation );
-gifit_app_container_element.addEventListener( 'keypress', stopImmediatePropagation );
-gifit_app_container_element.addEventListener( 'contextmenu', stopImmediatePropagation );
 
-// Engage party mode
-React.render( React.createElement(GifitButton, null), gifit_button_container_element );
-React.render( React.createElement(GifitApp, null), gifit_app_container_element );
+// Scan the page for YouTube players
+// Inject GIFit into all players found
+// This is super nasty but it's the least brittle way to do things. C'est la vie.
+var scanPage = function(){
+	var youtube_player_api_elements = document.querySelectorAll('#player-api:not(.gifit-initialized)');
+	for( var i = 0; i < youtube_player_api_elements.length; i ++ ){
+		initializeGifit( youtube_player_api_elements[i] );
+	}
+};
+
+scanPage();
+setInterval( scanPage, 1000 );
 
 },{"./components/GifitApp.jsx":"c:\\Users\\Timothy\\repos\\gifit\\src\\components\\GifitApp.jsx","./components/GifitButton.jsx":"c:\\Users\\Timothy\\repos\\gifit\\src\\components\\GifitButton.jsx","./styles/content.less":"c:\\Users\\Timothy\\repos\\gifit\\src\\styles\\content.less","react":"c:\\Users\\Timothy\\repos\\gifit\\node_modules\\react\\react.js"}],"c:\\Users\\Timothy\\repos\\gifit\\node_modules\\browserify\\node_modules\\events\\events.js":[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -9,7 +9,7 @@
             "vendor/patch-worker.js",
             "content.js"
         ],
-        "run_at": "document_end"
+        "run_at": "document_idle"
     }],
     "web_accessible_resources": [
         "vendor/gif.worker.js",

--- a/src/content.jsx
+++ b/src/content.jsx
@@ -6,25 +6,49 @@ var React = require('react');
 var GifitButton = require('./components/GifitButton.jsx');
 var GifitApp = require('./components/GifitApp.jsx');
 
-// Find YouTube elements we'll be injecting into
-var youtube_player_chrome_element = document.querySelector('#player-api .html5-player-chrome');
-var youtube_player_controls_element = document.querySelector('#player-api .html5-video-controls');
+var initializeGifit = function( youtube_player_api_element ){
 
-// We need containers since React.renderComponent annihilates the contents of its target
-var gifit_button_container_element = document.createElement('div');
-gifit_button_container_element.classList.add('ytp-button', 'ytp-button-gif');
-var gifit_app_container_element = document.createElement('div');
-youtube_player_chrome_element.appendChild( gifit_button_container_element );
-youtube_player_controls_element.appendChild( gifit_app_container_element );
+	// Find YouTube elements we'll be injecting into
+	var youtube_player_chrome_element = youtube_player_api_element.querySelector(':scope .html5-player-chrome');
+	var youtube_player_controls_element = youtube_player_api_element.querySelector(':scope .html5-video-controls');
 
-// Prevent YouTube's events from firing in Gifit's interface
-var stopImmediatePropagation = function( event ){
-	event.stopImmediatePropagation();
+	// If GIFit can't find the appropriate elements it does not start
+	if( !youtube_player_controls_element || !youtube_player_chrome_element ){
+		return;
+	}
+
+	// GIFit needs containers since React.renderComponent annihilates the contents of its target
+	var gifit_button_container_element = document.createElement('div');
+	gifit_button_container_element.classList.add('ytp-button', 'ytp-button-gif');
+	var gifit_app_container_element = document.createElement('div');
+	youtube_player_chrome_element.appendChild( gifit_button_container_element );
+	youtube_player_controls_element.appendChild( gifit_app_container_element );
+
+	// Prevent YouTube's events from firing in GIFit's interface
+	var stopImmediatePropagation = function( event ){
+		event.stopImmediatePropagation();
+	};
+	gifit_app_container_element.addEventListener( 'keydown', stopImmediatePropagation );
+	gifit_app_container_element.addEventListener( 'keypress', stopImmediatePropagation );
+	gifit_app_container_element.addEventListener( 'contextmenu', stopImmediatePropagation );
+
+	// Engage party mode
+	React.render( <GifitButton />, gifit_button_container_element );
+	React.render( <GifitApp />, gifit_app_container_element );
+
+	// Mark territory
+	youtube_player_api_element.classList.add('gifit-initialized');
 };
-gifit_app_container_element.addEventListener( 'keydown', stopImmediatePropagation );
-gifit_app_container_element.addEventListener( 'keypress', stopImmediatePropagation );
-gifit_app_container_element.addEventListener( 'contextmenu', stopImmediatePropagation );
 
-// Engage party mode
-React.render( <GifitButton />, gifit_button_container_element );
-React.render( <GifitApp />, gifit_app_container_element );
+// Scan the page for YouTube players
+// Inject GIFit into all players found
+// This is super nasty but it's the least brittle way to do things. C'est la vie.
+var scanPage = function(){
+	var youtube_player_api_elements = document.querySelectorAll('#player-api:not(.gifit-initialized)');
+	for( var i = 0; i < youtube_player_api_elements.length; i ++ ){
+		initializeGifit( youtube_player_api_elements[i] );
+	}
+};
+
+scanPage();
+setInterval( scanPage, 1000 );

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,7 @@
             "vendor/patch-worker.js",
             "content.js"
         ],
-        "run_at": "document_end"
+        "run_at": "document_idle"
     }],
     "web_accessible_resources": [
         "vendor/gif.worker.js",


### PR DESCRIPTION
In order to properly handle YouTube's AJAX+pushState page loading, GIFit needs to always be on the lookout for new player elements.

Hey, I *tried* hooking into the YouTube event system.

But ultimately GIFit will need to scan, because embedded players can appear any old time.